### PR TITLE
use proper url to avoid redirect and fix line anchor behavior

### DIFF
--- a/Support/lib/git_manager.rb
+++ b/Support/lib/git_manager.rb
@@ -116,7 +116,7 @@ class GitManager
   end
   
   def url_head(user_project, branch='')
-    branch = "tree/#{branch}" if branch != ''
+    branch = "blob/#{branch}" if branch != ''
     project_path = "/#{user_project[:user]}/#{user_project[:project]}/#{branch}"
     project_private?(project_path) ? 
       "https://github.com#{project_path}" : "http://github.com#{project_path}"

--- a/Support/lib/show_in_github.rb
+++ b/Support/lib/show_in_github.rb
@@ -19,7 +19,7 @@ module ShowInGitHub
   # -s strips user fu
   def line_to_github_url(file_path, line_str)
     return nil unless file_url = url_for(file_path)
-    project_url = file_url.sub(%r{/tree/.*/#{File.basename(file_path)}$}, '')
+    project_url = file_url.sub(%r{/blob/.*/#{File.basename(file_path)}$}, '')
     commit = git.find_commit_with_line(line_str)
     return nil unless commit
     file_index = commit.file_paths.index(git.relative_file(file_path))

--- a/Support/test/test_show_in_github.rb
+++ b/Support/test/test_show_in_github.rb
@@ -34,7 +34,7 @@ class TestShowInGithub < Test::Unit::TestCase
     })
     GitManager.any_instance.stubs(:working_path).returns("/some/path")
     url = ShowInGitHub.url_for("/some/path/to/file")
-    expected = "http://github.com/drnic/newgem/tree/master/to/file"
+    expected = "http://github.com/drnic/newgem/blob/master/to/file"
     assert_equal(expected, url)
   end
   
@@ -46,7 +46,7 @@ class TestShowInGithub < Test::Unit::TestCase
     })
     GitManager.any_instance.stubs(:working_path).returns("/some/path")
     url = ShowInGitHub.url_for("/some/path/to/file")
-    expected = "http://github.com/drnic/newgem-github/tree/master/to/file"
+    expected = "http://github.com/drnic/newgem-github/blob/master/to/file"
     assert_equal(expected, url)
   end
 
@@ -57,7 +57,7 @@ class TestShowInGithub < Test::Unit::TestCase
     })
     GitManager.any_instance.stubs(:working_path).returns("/some/path")
     url = ShowInGitHub.url_for("/some/path/to/file")
-    expected = "http://github.com/drnic/newgem-origin/tree/master/to/file"
+    expected = "http://github.com/drnic/newgem-origin/blob/master/to/file"
     assert_equal(expected, url)
   end
   
@@ -68,7 +68,7 @@ class TestShowInGithub < Test::Unit::TestCase
     })
     GitManager.any_instance.stubs(:working_path).returns("/some/path")
     url = ShowInGitHub.url_for("/some/path/to/file")
-    expected = "https://github.com/drnic/newgem/tree/master/to/file"
+    expected = "https://github.com/drnic/newgem/blob/master/to/file"
     assert_equal(expected, url)
   end
   
@@ -78,7 +78,7 @@ class TestShowInGithub < Test::Unit::TestCase
     })
     GitManager.any_instance.stubs(:working_path).returns("/some/path")
     url = ShowInGitHub.url_for("/some/path/to/file")
-    expected = "http://github.com/drnic/newgem/tree/master/to/file"
+    expected = "http://github.com/drnic/newgem/blob/master/to/file"
     assert_equal(expected, url)
   end
 end


### PR DESCRIPTION
Github switched urls from:

http://github.com/drnic/github-tmbundle/tree/master/Support/lib/git_manager.rb#L119

to:

http://github.com/drnic/github-tmbundle/blob/master/Support/lib/git_manager.rb#L119

Their redirect logic doesn't preserve anchors. This patch changes the bundle's behavior to use the proper url, restoring line number functionality.
