### PR TITLE
Removing usage of TM_RUBY

### DIFF
--- a/Commands/Add to multifile Gist.tmCommand
+++ b/Commands/Add to multifile Gist.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/add_to_multifile_gist.rb"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/add_to_multifile_gist.rb"
 </string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Annotate-Blame Command-Line.tmCommand
+++ b/Commands/Annotate-Blame Command-Line.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/comment_on_line.rb"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/comment_on_line.rb"
 
 </string>
 	<key>input</key>

--- a/Commands/Create Gist from Selection.tmCommand
+++ b/Commands/Create Gist from Selection.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/create_gist_from_selection.rb"</string>
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/create_gist_from_selection.rb"</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>

--- a/Commands/Create private Gist from Selection.tmCommand
+++ b/Commands/Create private Gist from Selection.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/create_gist_from_selection.rb" "private"</string>
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/create_gist_from_selection.rb" "private"</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>keyEquivalent</key>

--- a/Commands/Send multifile Gist.tmCommand
+++ b/Commands/Send multifile Gist.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/send_multifile_gist.rb"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/send_multifile_gist.rb"
 </string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Send private multifile Gist.tmCommand
+++ b/Commands/Send private multifile Gist.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/send_multifile_gist.rb" "private"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/send_multifile_gist.rb" "private"
 </string>
 	<key>input</key>
 	<string>selection</string>

--- a/Commands/Show Network in GitHub.tmCommand
+++ b/Commands/Show Network in GitHub.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/show_network_in_github.rb"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/show_network_in_github.rb"
 </string>
 	<key>input</key>
 	<string>document</string>

--- a/Commands/Show in GitHub.tmCommand
+++ b/Commands/Show in GitHub.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>RUBYLIB="$TM_BUNDLE_SUPPORT/lib:$RUBYLIB"
-"${TM_RUBY:=ruby}" -- "${TM_BUNDLE_SUPPORT}/bin/show_in_github.rb"
+ruby -- "${TM_BUNDLE_SUPPORT}/bin/show_in_github.rb"
 
 </string>
 	<key>input</key>


### PR DESCRIPTION
We are working to remove all usage of TM_RUBY outside of running the users own scripts, this is to keep the system-supplied version being the one used in most cases to prevent issues with newer ruby versions.
