### PR TITLE
this should have default of nil, so that it

### DIFF
--- a/Support/lib/git_manager.rb
+++ b/Support/lib/git_manager.rb
@@ -54,7 +54,7 @@ class GitManager
     end
   end  
   
-  def file_to_github_url(github_remote, branch='master', file=nil)
+  def file_to_github_url(github_remote, branch=nil, file=nil)
     file ||= target_file
     branch ||= @git.current_branch
     repo = repo_for_remote(github_remote)


### PR DESCRIPTION
becomes the current git branch

Otherwise, master is ALWAYS used.
