### PR TITLE
fix show in github for alt branches

### DIFF
--- a/Support/lib/git_manager.rb
+++ b/Support/lib/git_manager.rb
@@ -7,7 +7,7 @@ class GitManager
   attr_reader :git, :target_file
   
   def initialize(target_file)
-    @target_file = target_file || ""
+    @target_file = target_file
     find_working_dir
   end
   
@@ -54,7 +54,7 @@ class GitManager
     end
   end  
   
-  def file_to_github_url(github_remote, branch='master', file=nil)
+  def file_to_github_url(github_remote, branch=nil, file=nil)
     file ||= target_file
     branch ||= @git.current_branch
     repo = repo_for_remote(github_remote)


### PR DESCRIPTION
I noticed the show in github command was not working with branches other than 'master'. Turns out the git repo was not being initialized, but the manager was not failing because of the provided default.
